### PR TITLE
add VSCode debug configuration for Node backend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Node Backend",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -23,13 +23,26 @@ Install the dependencies:
 npm install
 ```
 
-Debug the application:
+### Debugging/Running the application
 
 ```sh
 npm run electron-dev
 ```
 
-Build the app manually for testing:
+### Debugging the Node Backend in VSCode
+
+We provide a debugging configuration for VSCode (defined in `.vscode/launch.json`)
+
+1. set a breakpoint in VSCode somewhere in the Node backend JS code (not front-end React code)
+2. `npm run electron-dev` (the Node debugger listens on port 9229)
+3. In VSCode, run the Debug Configuration named _Node Backend_. The VSCode status bar will turn orange when it is successfully attached to the debugger
+4. Use the Bible Karaoke application - the application will pause when a breakpoint is hit in VSCode
+
+### Debugging the React Frontend in VSCode
+
+TODO
+
+### Build and package the app manually for testing
 
 ```sh
 # Windows:
@@ -42,7 +55,7 @@ npm run electron-pack-linux
 
 Build the app automatically for distribution:
 
-- Push to a branch of the form `release/*`, e.g. `release/v0.3.4`, or `release/v0.3.4-rc1`.
+- Push to a branch of the form `release/*`, e.g. `release/v0.3.5`, or `release/v0.3.5-rc1`.
 - Look in the GitHub **Actions** tab for the build artifacts.
 
 Releasing

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "cli": "node public/cli/index.js",
-    "electron-dev": "concurrently \"cross-env BROWSER=none npm run start\" \"wait-on http://localhost:3000 && electron .\"",
+    "electron-dev": "concurrently \"cross-env BROWSER=none npm run start\" \"wait-on http://localhost:3000 && electron . --inspect 9229\"",
     "start": "ffbinaries ffmpeg ffprobe -o=binaries && rescripts start",
     "build": "ffbinaries ffmpeg ffprobe -o=binaries && rescripts build",
     "test": "rescripts test",


### PR DESCRIPTION
This adds a VSCode debug configuration for debugging the Node backend and updates the README with instructions for debugging.

Update README instructions:

![image](https://user-images.githubusercontent.com/3444521/98222009-e568eb00-1f82-11eb-94f2-24277965dbd9.png)

VSCode Debug Configuration can be run by clicking the run button: 
![image](https://user-images.githubusercontent.com/3444521/98222168-0f221200-1f83-11eb-8423-0cfd445e7dd2.png)



