### PR TITLE
Fix a missing peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8310,15 +8310,14 @@
       }
     },
     "eslint-plugin-ava": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-11.0.0.tgz",
-      "integrity": "sha512-UMGedfl/gIKx1tzjGtAsTSJgowyAEZU2VWmpoWXYcuuV4B2H4Cu90yuMgMPEVt1mQlIZ21L7YM2CSpHUFJo/LQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-10.5.0.tgz",
+      "integrity": "sha512-2I0Ze8ZtwbSlLdnzms4bsa6PxxOxGMIJ9d4yy7aRy3yc5zEO2wHJLic8l3Lrct73hb5ML+PLt5VRqvdV87xWdQ==",
       "dev": true,
       "requires": {
         "deep-strict-equal": "^0.2.0",
         "enhance-visitors": "^1.0.0",
-        "eslint-utils": "^2.1.0",
-        "espree": "^7.2.0",
+        "espree": "^7.1.0",
         "espurify": "^2.0.1",
         "import-modules": "^2.0.0",
         "micro-spelling-correcter": "^1.1.1",
@@ -8326,15 +8325,6 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
         "espree": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -10440,9 +10430,9 @@
       }
     },
     "import-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.0.0.tgz",
-      "integrity": "sha512-iczM/v9drffdNnABOKwj0f9G3cFDon99VcG1mxeBsdqnbd+vnQ5c2uAiCHNQITqFTOPaEvwg3VjoWCur0uHLEw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+      "integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
       "dev": true
     },
     "imurmurhash": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "electron": "^9.4.0",
     "electron-builder": "^22.7.0",
     "eslint": "^6.8.0",
-    "eslint-plugin-ava": "^11.0.0",
+    "eslint-plugin-ava": "^10.5.0",
     "eslint-plugin-react": "^7.20.6",
     "ffbinaries": "^1.1.4",
     "husky": "^4.3.0",


### PR DESCRIPTION
- downgrade eslint-plugin-ava to latest version that still supports eslint v6