### PR TITLE
get Node debugging working again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ binaries/ffprobe
 
 .eslintcache
 
+*.js.map
+
 # incrementally move to typescript.  Here are ignored JS files that are compiled
 /public/**/*.js
 /start/

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -10,7 +10,8 @@
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
     "jsx": "react",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true
   },
   "include": ["public/*.ts", "public/**/*.ts", "typings"],
   "exclude": ["node_modules", "**/*.integration.ts"]


### PR DESCRIPTION
This PR instructs the TSC to generate source maps, which can be used by VSCode to validate breakpoints when debugging backend Node.js code.  From my limited experience, the Node debugger is still working fine and can now correctly validate breakpoints in the Typescript code.  This is for back-end / electron code, not the render process / React code.

Here is a working screenshot:
![image](https://user-images.githubusercontent.com/3444521/127838898-d704d8d2-0bf5-4cdf-ab34-1c005fa7d64a.png)

Fixes #168 