### PR TITLE
Render headings

### DIFF
--- a/public/cli/lib/rendering/render.html
+++ b/public/cli/lib/rendering/render.html
@@ -50,6 +50,11 @@
       .karaoke-caption .words {
         display: inline-block;
       }
+
+      .karaoke-heading {
+        font-weight: "bold";
+      }
+
       #imgParent {
         width: 720px;
         height: 480px;
@@ -134,7 +139,12 @@
               next: "p" + (i + 1),
             });
             // concat the lines together with all words inside
-            lyrics += "<div class='phrase' id='p" + i + "'>" + text + "</div>";
+            lyrics += "<div class='phrase";
+            //Add karaoke-heading class if the line is a heading;
+            if(line.isHeading) {
+              lyrics += " karaoke-heading";
+            }
+            lyrics += "' id='p" + i + "'>" + text + "</div>";
             i++;
           });
 

--- a/public/cli/lib/rendering/renderFrames.spec.ts
+++ b/public/cli/lib/rendering/renderFrames.spec.ts
@@ -73,6 +73,7 @@ function mockTimings(): Timings {
       duration: 100,
       content: 'Hello World',
       text: '',
+      isHeading: false,
       words: [
         { word: 'Hello', start: 1, end: 5 },
         { word: 'World', start: 6, end: 10 },

--- a/public/cli/lib/rendering/timings.spec.ts
+++ b/public/cli/lib/rendering/timings.spec.ts
@@ -39,6 +39,7 @@ test('timings.chapterFormatToTimings test', (t) => {
       duration: 5300,
       content: 'In the beginning God created the heavens and the earth.',
       text: '',
+      isHeading: false,
       words: [
         { end: 1329, start: 1040, word: 'In' },
         { end: 1714, start: 1329, word: 'the' },
@@ -61,6 +62,7 @@ test('timings.chapterFormatToTimings test', (t) => {
       content:
         'Now the earth was formless and empty, darkness was over the surface of the deep, and the Spirit of God was hovering over the waters.',
       text: '',
+      isHeading: false,
       words: [
         { end: 7322, start: 7040, word: 'Now' },
         { end: 7604, start: 7322, word: 'the' },

--- a/public/cli/lib/rendering/timings.ts
+++ b/public/cli/lib/rendering/timings.ts
@@ -14,6 +14,7 @@ export function chapterFormatToTimings(chapter: BKChapter): Timings {
       content: segment.text,
       text: '',
       words: [],
+      isHeading: segment.isHeading,
     };
     formatWords(contentWords, lineTiming);
     timings.push(lineTiming);

--- a/public/models/timings.model.ts
+++ b/public/models/timings.model.ts
@@ -10,6 +10,7 @@ export interface LineTiming {
   readonly content: string;
   readonly text: string; // not used
   readonly words: WordTiming[];
+  readonly isHeading: Boolean;
 }
 
 interface WordTiming {


### PR DESCRIPTION
- Change the timing model to store `isHeading`
- Add karoake-heading class and assign it to phrase that are headings in `render.html`

No tests written yet, can follow the render images tests Chris is working