### PR TITLE
Fix #200 book order is not canonical

### DIFF
--- a/public/sources/hear-this.ts
+++ b/public/sources/hear-this.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { flatten } from 'lodash';
-import { Project, Book, Chapter, getDirectories } from './util';
+import { Project, Book, Chapter, getDirectories, sortInCanonicalOrder } from './util';
 import ProjectSource from '../models/projectSource.model';
 
 const PROJECT_TYPE = 'hearThis';
@@ -30,7 +30,7 @@ class HearThis implements ProjectSource {
     const project = new Project(PROJECT_TYPE);
     project.name = name;
     project.fullPath = path.join(directory, name);
-    const bookNames = getDirectories(project.fullPath);
+    const bookNames = sortInCanonicalOrder(getDirectories(project.fullPath));
     project.books = bookNames
       .map((bookName: string) => this.makeBook(name, bookName, directory))
       .filter((book: Book) => book.chapters.length);

--- a/public/sources/util.spec.ts
+++ b/public/sources/util.spec.ts
@@ -1,0 +1,12 @@
+import test from 'ava';
+import { sortInCanonicalOrder } from './util';
+
+test('sorts books canonically', (t) => {
+  const bookNames = ['Revelation', 'Genesis', 'Matthew', 'Psalms'];
+  t.deepEqual(sortInCanonicalOrder(bookNames), ['Genesis', 'Psalms', 'Matthew', 'Revelation']);
+});
+
+test('appends unrecognised books to end', (t) => {
+  const bookNames = ['Revelation', 'Genesis', 'Not-a-book', 'Matthew', 'Psalms'];
+  t.deepEqual(sortInCanonicalOrder(bookNames), ['Genesis', 'Psalms', 'Matthew', 'Revelation', 'Not-a-book']);
+});

--- a/public/sources/util.ts
+++ b/public/sources/util.ts
@@ -11,6 +11,102 @@ export function getDirectories(source: string): string[] {
   return fs.readdirSync(source).filter((name) => isDirectory(path.join(source, name)));
 }
 
+export function sortInCanonicalOrder(bookNames: string[]): string[] {
+  // OT list according to https://en.wikipedia.org/wiki/Biblical_canon#/media/File:Development_of_the_Old_Testament.svg
+  // USFM list here: https://ubsicap.github.io/usfm/identification/books.html
+  const CANONICAL_BOOK_ORDER = [
+    'Genesis',
+    'Exodus',
+    'Leviticus',
+    'Numbers',
+    'Deuteronomy',
+    'Joshua',
+    'Judges',
+    'Ruth',
+    '1 Samuel',
+    '2 Samuel',
+    '1 Kings',
+    '2 Kings',
+    '3 Kings',
+    '4 Kings',
+    'Ezra',
+    'Nehemiah',
+    '1 Esdras',
+    '2 Esdras',
+    'Tobit',
+    'Judith',
+    'Esther',
+    '1 Maccabees',
+    '2 Maccabees',
+    '3 Maccabees',
+    '4 Maccabees',
+    'Job',
+    'Psalms',
+    'Proverbs',
+    'Ecclesiastes',
+    'Song of Songs',
+    'Wisdom',
+    'Sirach',
+    'Isaiah',
+    'Jeremiah',
+    'Lamentations',
+    'Baruch',
+    'Ezekiel',
+    'Daniel',
+    'Hosea',
+    'Joel',
+    'Amos',
+    'Obadiah',
+    'Jonah',
+    'Micah',
+    'Nahum',
+    'Habakkuk',
+    'Zephaniah',
+    'Haggai',
+    'Zechariah',
+    'Malachi',
+    'Matthew',
+    'Mark',
+    'Luke',
+    'John',
+    'Acts',
+    'Romans',
+    '1 Corinthians',
+    '2 Corinthians',
+    'Galatians',
+    'Ephesians',
+    'Philippians',
+    'Colossians',
+    '1 Thessalonians',
+    '2 Thessalonians',
+    '1 Timothy',
+    '2 Timothy',
+    'Titus',
+    'Philemon',
+    'Hebrews',
+    'James',
+    '1 Peter',
+    '2 Peter',
+    '1 John',
+    '2 John',
+    '3 John',
+    'Jude',
+    'Revelation',
+    'Apocalypse'
+  ];
+  const sortedBooks: string[] = [];
+  CANONICAL_BOOK_ORDER.forEach(book => {
+    const index = bookNames.indexOf(book);
+    if (index >= 0) {
+      // move bookName from bookNames into sortedBooks
+      sortedBooks.push(...bookNames.splice(index, 1));
+    }
+  });
+  // append unrecognised books to the end
+  return sortedBooks.concat(bookNames);
+}
+
+
 export class Project {
   projectType: string;
   name: string;


### PR DESCRIPTION
Since the HearThis project format uses directory names as books, and directories have no concept of sort order, we need to use a hard-coded list of books in canonical order. If SIL/UBS/Paratext has an official list of canonical books in order I'm very happy to use it. The best I could find was the USFM definition here: https://ubsicap.github.io/usfm/identification/books.html.

Note this change only affects HearThis projects. I looked for the SAB equivalent but it appears to be unimplemented.

I was surprised that applying this sort in `public/cli/lib/import/hearThis/readStructure.ts` does not appear to have any effect. Can you shed any light on that?

This is my first pull request to this repository so all feedback is very welcome!