### PR TITLE
Fix pre-commit lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lint-staged
+npx --no-install lint-staged


### PR DESCRIPTION
- this has not been working since we upgraded `husky` to v6 (from v4).