### PR TITLE
Address console warnings from eslint react

### DIFF
--- a/src/App/components/Settings.tsx
+++ b/src/App/components/Settings.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import _ from 'lodash';
-import styled from 'styled-components';
-import { Flex } from 'reflexbox';
-import { Icon, Tooltip, Classes, Position} from '@blueprintjs/core';
-import { useObserver } from 'mobx-react';
-import { repository } from '../../../package.json';
-import { H5, Colors, Text, Card, Button, Checkbox } from '../blueprint';
-import { useStores } from '../store';
-import { useAnalytics } from './Analytics';
-import { getDefaultHearThisDirectory, getDefaultScriptureAppBuilderDirectory } from '../store/Settings';
-import FileSelector from './FileSelector';
-import { DEFAULT_OUTPUT_DIRECTORY } from '../constants';
+import React from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames";
+import _ from "lodash";
+import styled from "styled-components";
+import { Flex } from "reflexbox";
+import { Icon, Tooltip, Classes, Position } from "@blueprintjs/core";
+import { useObserver } from "mobx-react";
+import { repository } from "../../../package.json";
+import { H5, Colors, Text, Card, Button, Checkbox } from "../blueprint";
+import { useStores } from "../store";
+import { useAnalytics } from "./Analytics";
+import { getDefaultHearThisDirectory, getDefaultScriptureAppBuilderDirectory } from "../store/Settings";
+import FileSelector from "./FileSelector";
+import { DEFAULT_OUTPUT_DIRECTORY } from "../constants";
 
 const DirectoryHeading = styled(Flex)`
   .file-selector > * {
@@ -59,7 +59,7 @@ const DirectoriesCard = (prop: DirectoriesCardInterface): JSX.Element => {
             buttonIcon="folder-new"
             options={{
               title: `Select ${prop.name} folder`,
-              properties: ['openDirectory'],
+              properties: ["openDirectory"],
             }}
             onFileSelected={addDirectory}
           />
@@ -95,11 +95,11 @@ DirectoriesCard.propTypes = {
 export default function Settings(): JSX.Element {
   const { settings } = useStores();
   const { analytics } = useAnalytics();
-  const repoUrl = repository.url.replace(/\.git$/, '');
+  const repoUrl = repository.url.replace(/\.git$/, "");
   const resetOutputDir = (): void => settings.setOutputDirectory(DEFAULT_OUTPUT_DIRECTORY);
   React.useEffect(() => {
-    analytics.trackScreenview('Settings');
-  }, []);
+    analytics.trackScreenview("Settings");
+  }, [analytics]);
   return useObserver(() => (
     <Flex
       backgroundColor={Colors.background2}
@@ -129,13 +129,13 @@ export default function Settings(): JSX.Element {
             buttonText="Save videos to..."
             file={settings.outputDirectory}
             options={{
-              title: 'Select Output Folder',
-              properties: ['openDirectory'],
+              title: "Select Output Folder",
+              properties: ["openDirectory"],
             }}
             onFileSelected={settings.setOutputDirectory}
           />
           <Tooltip content="Reset to default directory" position={Position.BOTTOM}>
-              <Button minimal icon="reset" onClick={resetOutputDir} />
+            <Button minimal icon="reset" onClick={resetOutputDir} />
           </Tooltip>
         </Flex>
         <Checkbox
@@ -169,7 +169,7 @@ export default function Settings(): JSX.Element {
         />
       </Card>
       <Text mt={3} textAlign="center" className={descriptionTextClass}>
-        This software is released under the{' '}
+        This software is released under the{" "}
         <a target="_blank" rel="noopener noreferrer" href={`${repoUrl}/blob/master/LICENSE.md`}>
           MIT License
         </a>

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -1,18 +1,18 @@
-import { ipcRenderer } from 'electron';
-import React from 'react';
-import { useObserver } from 'mobx-react';
-import styled, { StyledComponent } from 'styled-components';
-import { Classes } from '@blueprintjs/core';
-import { BoxType, Flex } from 'reflexbox';
-import { Colors } from './blueprint';
-import AppHeader from './components/AppHeader';
-import BookSelector from './components/BookSelector';
-import ChapterSelector from './components/ChapterSelector';
-import Preview from './components/Preview';
-import Actions from './components/Actions';
-import { useStores } from './store';
-import { AnalyticsContext, useAnalytics } from './components/Analytics';
-import './index.scss';
+import { ipcRenderer } from "electron";
+import React from "react";
+import { useObserver } from "mobx-react";
+import styled, { StyledComponent } from "styled-components";
+import { Classes } from "@blueprintjs/core";
+import { BoxType, Flex } from "reflexbox";
+import { Colors } from "./blueprint";
+import AppHeader from "./components/AppHeader";
+import BookSelector from "./components/BookSelector";
+import ChapterSelector from "./components/ChapterSelector";
+import Preview from "./components/Preview";
+import Actions from "./components/Actions";
+import { useStores } from "./store";
+import { AnalyticsContext, useAnalytics } from "./components/Analytics";
+import "./index.scss";
 
 const AppWrapper: StyledComponent<BoxType, any, {}> = styled(Flex)`
   position: relative;
@@ -23,15 +23,21 @@ export default function App(): JSX.Element {
   const analyticsContext: AnalyticsContext = useAnalytics();
 
   React.useEffect((): void => {
-    ipcRenderer.send('did-start-getprojectstructure', storeRecord.settings.rootDirectories);
+    ipcRenderer.send("did-start-getprojectstructure", storeRecord.settings.rootDirectories);
   }, [storeRecord.settings.rootDirectories]);
 
   React.useEffect((): void => {
-    analyticsContext.analytics.trackScreenview('Home');
-  }, []);
+    analyticsContext.analytics.trackScreenview("Home");
+  }, [analyticsContext]);
 
   return useObserver(() => (
-    <AppWrapper minWidth="1024px" backgroundColor={Colors.background3} height="100%" className={Classes.DARK} flexDirection="column">
+    <AppWrapper
+      minWidth="1024px"
+      backgroundColor={Colors.background3}
+      height="100%"
+      className={Classes.DARK}
+      flexDirection="column"
+    >
       <AppHeader />
       <Flex flex={1} flexDirection="column" overflowY="auto">
         <Flex flex={1}>


### PR DESCRIPTION
I was working on #183 but the original console warning addressed by that commit seems to have vanished without a merge. So I decided to fix a different set of console warnings.

I have checked that the analytics context does not change, so it does not trigger a re-render. No functional change.