### PR TITLE
Fix #213 Make project list refresh when folders are changed

### DIFF
--- a/src/App/store/Settings.ts
+++ b/src/App/store/Settings.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { persist } from 'mobx-persist';
 import { PROJECT_TYPE, DEFAULT_OUTPUT_DIRECTORY } from '../constants';
 import Store from '.';
+import { ipcRenderer } from 'electron';
 
 export const getDefaultHearThisDirectory = (): string => {
   switch (process.platform) {
@@ -63,11 +64,13 @@ class Settings {
   @action.bound
   setHearThisRootDirectories(directories: string[]): void {
     this.hearThisRootDirectories = directories;
+    ipcRenderer.send('did-start-getprojectstructure', this.rootDirectories);
   }
 
   @action.bound
   setScriptureAppBuilderRootDirectories(directories: string[]): void {
     this.scriptureAppBuilderRootDirectories = directories;
+    ipcRenderer.send('did-start-getprojectstructure', this.rootDirectories);
   }
 
   @action.bound


### PR DESCRIPTION
I've fixed the problem. However, it appears to me that the following code in `src\App\index.tsx` should already be addressing it:
```javascript
React.useEffect((): void => {
    ipcRenderer.send("did-start-getprojectstructure", storeRecord.settings.rootDirectories);
  }, [storeRecord.settings.rootDirectories]);
```
Shouldn't this be sending `did-start-getprojectstructure` whenever there are changes to `storeRecord.settings.rootDirectories`?