### PR TITLE
Don't render segments marked skipped in HearThis

### DIFF
--- a/public/cli/lib/commands/convert.ts
+++ b/public/cli/lib/commands/convert.ts
@@ -59,12 +59,7 @@ export async function convert(
       if (!isCombined) {
         outputName = checkOverwrite(outputName, animationSettings.output.overwriteOutputFiles);
       }
-      let audioFiles: string[] = [];
-      if ('filename' in chapter.audio) {
-        audioFiles = [chapter.audio.filename];
-      } else {
-        audioFiles = chapter.audio.files.map((f) => f.filename);
-      }
+      const audioFiles = chapter.audio.files.map((f) => f.filename);
       let audioDuration = 0;
       if (chapter.audio.length) {
         audioDuration = chapter.audio.length;

--- a/public/cli/lib/import/hearThis/test/fullImport.integration.ts
+++ b/public/cli/lib/import/hearThis/test/fullImport.integration.ts
@@ -134,7 +134,12 @@ const expected = {
         {
           name: '3',
           audio: {
-            filename: join(testPaths.exampleHearThisProjectPath, 'Book1', '3', '0.wav'),
+            files: [
+              {
+                filename: join(testPaths.exampleHearThisProjectPath, 'Book1', '3', '0.wav'),
+                length: 1400,
+              },
+            ],
             length: 1400,
           },
           segments: [

--- a/public/cli/lib/import/hearThis/test/scenarios/scenario2.ts
+++ b/public/cli/lib/import/hearThis/test/scenarios/scenario2.ts
@@ -28,7 +28,12 @@ export const scenario2 = {
           {
             name: '3',
             audio: {
-              filename: path.join(testPaths.exampleHearThisProjectPath, 'Book1', '3', '0.wav'),
+              files: [
+                {
+                  filename: path.join(testPaths.exampleHearThisProjectPath, 'Book1', '3', '0.wav'),
+                  length: 1400,
+                },
+              ],
               length: 1400,
             },
             segments: [

--- a/public/cli/lib/rendering/timings.spec.ts
+++ b/public/cli/lib/rendering/timings.spec.ts
@@ -7,8 +7,16 @@ test('timings.chapterFormatToTimings test', (t) => {
   const chapter: BKChapter = {
     name: '1',
     audio: {
-      filename: 'audio.mp3',
-      length: 92700,
+      files: [
+        {
+          filename: '0.mp3',
+          length: 34600,
+        },
+        {
+          filename: '1.mp3',
+          length: 56400,
+        },
+      ],
     },
     segments: [
       {
@@ -25,6 +33,15 @@ test('timings.chapterFormatToTimings test', (t) => {
         verse: '2',
         startTime: 7040,
         length: 9300,
+        isHeading: false,
+      },
+      // this segment has no audio and should be skipped
+      {
+        segmentId: 3,
+        text: 'And God said, “Let there be light,” and there was light.',
+        verse: '3',
+        startTime: 17200,
+        length: 5400,
         isHeading: false,
       },
     ],

--- a/public/cli/lib/rendering/timings.ts
+++ b/public/cli/lib/rendering/timings.ts
@@ -1,23 +1,27 @@
 import { Timings, LineTiming } from '../../../models/timings.model';
 import { BKChapter } from '../../../models/projectFormat.model';
+import { getAudioIndexes } from '../../../sources/util';
 
 export function chapterFormatToTimings(chapter: BKChapter): Timings {
+  const audioIndexes = getAudioIndexes(chapter.audio);
   const timings: Timings = [];
   for (const segment of chapter.segments) {
-    const contentWords = segment.text.split(' ');
-    const lineTiming: LineTiming = {
-      type: 'caption',
-      index: segment.segmentId,
-      start: segment.startTime,
-      end: segment.startTime + segment.length,
-      duration: segment.length,
-      content: segment.text,
-      text: '',
-      words: [],
-      isHeading: segment.isHeading,
-    };
-    formatWords(contentWords, lineTiming);
-    timings.push(lineTiming);
+    if (audioIndexes.includes(segment.segmentId - 1)) {
+      const contentWords = segment.text.split(' ');
+      const lineTiming: LineTiming = {
+        type: 'caption',
+        index: segment.segmentId,
+        start: segment.startTime,
+        end: segment.startTime + segment.length,
+        duration: segment.length,
+        content: segment.text,
+        text: '',
+        words: [],
+        isHeading: segment.isHeading,
+      };
+      formatWords(contentWords, lineTiming);
+      timings.push(lineTiming);
+    }
   }
   return timings;
 }

--- a/public/cli/lib/rendering/timings.ts
+++ b/public/cli/lib/rendering/timings.ts
@@ -1,6 +1,6 @@
 import { Timings, LineTiming } from '../../../models/timings.model';
-import { BKChapter } from '../../../models/projectFormat.model';
-import { getAudioIndexes } from '../../../sources/util';
+import { BKChapter, BKAudio } from '../../../models/projectFormat.model';
+import path from 'path';
 
 export function chapterFormatToTimings(chapter: BKChapter): Timings {
   const audioIndexes = getAudioIndexes(chapter.audio);
@@ -48,4 +48,12 @@ function formatWords(words: string[], lineTiming: LineTiming): void {
     lineTiming.words.push({ word, start, end });
     start = end;
   }
+}
+
+function getAudioIndexes(audio: BKAudio): number[] {
+  const audioIndexes = [];
+  for (const file of audio.files) {
+    audioIndexes.push(parseInt(path.parse(file.filename).name));
+  }
+  return audioIndexes;
 }

--- a/public/models/projectFormat.model.ts
+++ b/public/models/projectFormat.model.ts
@@ -12,17 +12,15 @@ interface BKBook {
 
 export interface BKChapter {
   readonly name: string;
-  audio: BKAudio | BKAudioMultipleFiles;
+  audio: BKAudio;
   readonly segments: BKSegment[];
 }
 
-interface BKAudio {
-  filename: string;
-  length: number;
-}
-
-interface BKAudioMultipleFiles {
-  files: BKAudio[];
+export interface BKAudio {
+  files: {
+    filename: string;
+    length: number;
+  }[];
   length?: number;
 }
 

--- a/public/sources/hear-this.ts
+++ b/public/sources/hear-this.ts
@@ -3,10 +3,11 @@ import path from 'path';
 import { flatten } from 'lodash';
 import { Project, Book, Chapter, getDirectories, sortInCanonicalOrder } from './util';
 import ProjectSource from '../models/projectSource.model';
+import { fileFilters } from '../../src/App/constants';
+import { isValidAudioFile } from './util';
+import { DEFAULT_HEARTHIS_XML_FILE } from '../../src/App/constants';
 
 const PROJECT_TYPE = 'hearThis';
-
-const DEFAULT_XML_NAME = 'info.xml';
 
 class HearThis implements ProjectSource {
   get PROJECT_TYPE(): string {
@@ -57,10 +58,10 @@ class HearThis implements ProjectSource {
     chapter.name = parseInt(name).toString();
     const chapterFiles = fs.readdirSync(path.join(directory, projectName, bookName, name));
     chapter.audioFiles = chapterFiles
-      .filter((file: string) => file !== DEFAULT_XML_NAME)
+      .filter((file: string) => isValidAudioFile(file, DEFAULT_HEARTHIS_XML_FILE, fileFilters.audio[0].extensions))
       .map((fileName: string) => path.join(directory, projectName, bookName, name, fileName));
 
-    chapter.textXmlFile = chapterFiles.find((file: string) => file === DEFAULT_XML_NAME);
+    chapter.textXmlFile = chapterFiles.find((file: string) => file === DEFAULT_HEARTHIS_XML_FILE);
     if (chapter.textXmlFile)
       chapter.textXmlFile = path.join(directory, projectName, bookName, name, chapter.textXmlFile);
     chapter.fullPath = path.join(directory, projectName, bookName, name);

--- a/public/sources/hear-this.ts
+++ b/public/sources/hear-this.ts
@@ -5,9 +5,10 @@ import { Project, Book, Chapter, getDirectories, sortInCanonicalOrder } from './
 import ProjectSource from '../models/projectSource.model';
 import { fileFilters } from '../../src/App/constants';
 import { isValidAudioFile } from './util';
-import { DEFAULT_HEARTHIS_XML_FILE } from '../../src/App/constants';
 
 const PROJECT_TYPE = 'hearThis';
+
+export const DEFAULT_HEARTHIS_XML_FILE = 'info.xml';
 
 class HearThis implements ProjectSource {
   get PROJECT_TYPE(): string {

--- a/public/sources/util.spec.ts
+++ b/public/sources/util.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { sortInCanonicalOrder } from './util';
+import { sortInCanonicalOrder, isValidAudioFile } from './util';
 
 test('sorts books canonically', (t) => {
   const bookNames = ['Revelation', 'Genesis', 'Matthew', 'Psalms'];
@@ -9,4 +9,25 @@ test('sorts books canonically', (t) => {
 test('appends unrecognised books to end', (t) => {
   const bookNames = ['Revelation', 'Genesis', 'Not-a-book', 'Matthew', 'Psalms'];
   t.deepEqual(sortInCanonicalOrder(bookNames), ['Genesis', 'Psalms', 'Matthew', 'Revelation', 'Not-a-book']);
+});
+
+test('check valid audio file', (t) => {
+  const fileName = 'file.mp4';
+  const defaultXmlName = 'index.xml';
+  const audioFilters = ['mp4', 'webm'];
+  t.true(isValidAudioFile(fileName, defaultXmlName, audioFilters));
+});
+
+test('check not valid audio file', (t) => {
+  const fileName = 'file.mp4';
+  const defaultXmlName = 'index.xml';
+  const audioFilters = ['webm', 'avi'];
+  t.false(isValidAudioFile(fileName, defaultXmlName, audioFilters));
+});
+
+test('check is xml file', (t) => {
+  const fileName = 'index.xml';
+  const defaultXmlName = 'index.xml';
+  const audioFilters = ['mp4', 'webm'];
+  t.false(isValidAudioFile(fileName, defaultXmlName, audioFilters));
 });

--- a/public/sources/util.ts
+++ b/public/sources/util.ts
@@ -2,9 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import xml2json from 'xml-js';
 import { ScriptLine } from '../cli/lib/import/hearThis/hearThisImport';
-import { BKAudio } from '../models/projectFormat.model';
 import { fileFilters } from '../../src/App/constants';
-import { DEFAULT_HEARTHIS_XML_FILE } from '../../src/App/constants';
+import { DEFAULT_HEARTHIS_XML_FILE } from './hear-this';
 
 export function isDirectory(source: string): boolean {
   return fs.lstatSync(source).isDirectory();
@@ -193,14 +192,6 @@ function filePathToAudioIndexes(sourceDirectory: string): string[] {
     indexes.push(path.parse(file).name);
   }
   return indexes;
-}
-
-export function getAudioIndexes(audio: BKAudio): number[] {
-  const audioIndexes = [];
-  for (const file of audio.files) {
-    audioIndexes.push(parseInt(path.parse(file.filename).name));
-  }
-  return audioIndexes;
 }
 
 export function isValidAudioFile(file: string, defaultXmlName: string, audioFilters: string[]): boolean {

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -3,8 +3,6 @@ import path from 'path';
 
 export const DEFAULT_BG_COLOR = '#000';
 
-export const DEFAULT_HEARTHIS_XML_FILE = 'info.xml';
-
 export const BACKGROUND_TYPE = {
   image: 'image',
   video: 'video',

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -3,6 +3,8 @@ import path from 'path';
 
 export const DEFAULT_BG_COLOR = '#000';
 
+export const DEFAULT_HEARTHIS_XML_FILE = 'info.xml';
+
 export const BACKGROUND_TYPE = {
   image: 'image',
   video: 'video',


### PR DESCRIPTION
When a segment is marked skipped in HearThis the audio file extension is changed to `.skip`. This pull request makes sure all segments have valid corresponding audio.