### PR TITLE
Fix #226 Don't list empty projects

### DIFF
--- a/main/sources/hear-this.ts
+++ b/main/sources/hear-this.ts
@@ -19,7 +19,9 @@ class HearThis implements ProjectSource {
     try {
       return flatten(
         rootDirectories.map((directory: string) => {
-          return getDirectories(directory).map((name: string) => this.makeProject(name, directory));
+          return getDirectories(directory)
+            .map((name: string) => this.makeProject(name, directory))
+            .filter((project: Project) => project.books.length);
         })
       );
     } catch (error) {


### PR DESCRIPTION
Looks like this has been a problem for a while. Any non-valid project (like an empty folder) would show up in the list.