### PR TITLE
enable npm cache in github CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node_version }}
+          cache: 'npm'
       - run: npm ci
       - run: npm run lint
       - run: npm run build


### PR DESCRIPTION
Enable npm caching.  Npm caching is disabled by default, per the docs: https://github.com/actions/setup-node#caching-packages-dependencies.

**GA Build time with no npm caching: 4:33
GA Build time with npm caching: 2:25**

A drop of about 2 minutes - this seems like a win for minimal effort.