### PR TITLE
move z-index attribute on component to be styled attribute

### DIFF
--- a/src/App/components/BookSelector.tsx
+++ b/src/App/components/BookSelector.tsx
@@ -34,7 +34,7 @@ const BookSelector = observer((props: CardProps): JSX.Element | null => {
             >
               {book.name}
               {book.isSelected && project.bookSelection.length > 1 && (
-                <Tag position="absolute" zIndex={2} right="-10px" top="-10px" round intent={Intent.SUCCESS}>
+                <Tag position="absolute" style={{zIndex:2}} right="-10px" top="-10px" round intent={Intent.SUCCESS}>
                   {selectionCount}
                 </Tag>
               )}


### PR DESCRIPTION
This PR fixes the console error seen here:
![bk_zindex_error](https://user-images.githubusercontent.com/3444521/145972435-699c2b8a-d5fb-4313-8dcd-9c76ddc06891.JPG)
Repro steps for console error:
- `npm run electron-dev`
- select a project and click on multiple books and multiple chapters
- see the console error in the dev tools
- In my experience, the error only appears once, and doesn't fire multiple times

This change also allows the Tag component to properly display with a z-index as seen here:
![image](https://user-images.githubusercontent.com/3444521/145972406-ce5d835c-8135-44eb-998a-094baf917d65.png)

This fix was originally proposed in #183 (thanks @guyyoo ) and @iamam34 and @JCFarrow correctly identified the core of this change.  Unfortunately, #183 was closed without merging due to reproducibility issues.  With the steps above, I am confident that this is a worth-while fix.

Here are more details:

React components have a well-defined set of properties, and setting arbitrary properties on a component can generate a console error e.g.

"React does not recognize the X property on an element."
See the docs: https://reactjs.org/warnings/unknown-prop.html

In this case, the Tag component provided by Blueprint.JS "may" have had a zIndex property in the past, however the current blueprint.js docs show this property no longer exists.
See: https://blueprintjs.com/docs/#core/components/tag

This created a situation where our custom blueprint.ts file allowed the property to exist when in fact React doesn't allow it.  I'm not entirely sure what to do to make the TS compiler fix these types of React component "unknown prop" errors at compile time.

This change fixes the console error, as well as the z-index styling on the component itself, allowing the tag to be placed above the other components.