### PR TITLE
Fix #255 Make audio of different sample rates combine correctly

### DIFF
--- a/main/commands/combineVideos.ts
+++ b/main/commands/combineVideos.ts
@@ -1,7 +1,5 @@
 import { spawnSync } from 'child_process';
 import { EventEmitter } from 'events';
-import { writeFileSync } from 'fs';
-import tmp from 'tmp-promise';
 import winston from 'winston';
 import { paths } from '../path-constants';
 
@@ -14,6 +12,7 @@ export async function combineVideos(
   notifyEvent && notifyEvent.emit('Combining Videos');
   const args: string[] = ['-v', 'error'];
   const filterComplex: string[] = [];
+  // create FFmpeg command to combine the videos (https://ffmpeg.org/ffmpeg-filters.html#concat)
   for (let i = 0; i < videoPaths.length; i++) {
     args.push('-i', videoPaths[i]);
     filterComplex.push(`[${i}:0]`, `[${i}:1]`);

--- a/main/commands/combineVideos.ts
+++ b/main/commands/combineVideos.ts
@@ -10,22 +10,19 @@ export async function combineVideos(
   outputFilePath: string,
   notifyEvent?: EventEmitter
 ): Promise<void> {
-  winston.info('Generating videoList file');
-  notifyEvent && notifyEvent.emit('Generating videoList file');
-  tmp.setGracefulCleanup();
-  // Create a temporary list file to concatenate videos (see https://trac.ffmpeg.org/wiki/Concatenate)
-  const { path: file, cleanup } = await tmp.file({ postfix: '.txt' });
-  const contents = videoPaths.map((videoPath) => `file '${videoPath}'`).join('\n');
-  writeFileSync(file, contents);
   winston.info('Combining Videos');
   notifyEvent && notifyEvent.emit('Combining Videos');
-  const combineProcess = spawnSync(
-    paths.ffmpeg,
-    ['-f', 'concat', '-loglevel', 'error', '-safe', '0', '-i', file, '-c', 'copy', outputFilePath],
-    {
-      stdio: 'pipe',
-    }
-  );
+  const args: string[] = ['-v', 'error'];
+  const filterComplex: string[] = [];
+  for (let i = 0; i < videoPaths.length; i++) {
+    args.push('-i', videoPaths[i]);
+    filterComplex.push(`[${i}:0]`, `[${i}:1]`);
+  }
+  filterComplex.push(`concat=n=${videoPaths.length}:v=1:a=1`, '[v]', '[a]');
+  args.push('-filter_complex', filterComplex.join(' '), '-map', '[v]', '-map', '[a]', outputFilePath);
+  const combineProcess = spawnSync(paths.ffmpeg, args, {
+    stdio: 'pipe',
+  });
   const stderr = combineProcess.stderr.toString();
   if (stderr !== '') {
     winston.error(stderr);
@@ -34,5 +31,4 @@ export async function combineVideos(
     winston.info('Videos Combined');
     notifyEvent && notifyEvent.emit('Videos Combined');
   }
-  cleanup();
 }


### PR DESCRIPTION
I changed the combining FFmpeg command from using a concat demuxer (https://ffmpeg.org/ffmpeg-formats.html#concat-1) to using a complex filter (https://ffmpeg.org/ffmpeg-filters.html#concat). The demuxer doesn't allow for re-encoding which was what needed to happen with the audio for FFmpeg to fix the sample rate discrepancy.

Steps for testing:
1. Download "BK Test" and "BK Test Audio" from BK google drive > Developer Resources > SAB Projects (https://drive.google.com/drive/u/0/folders/1a2Ggia3GbIFgFiB9GwCmoF6TLOV9-HI0)
2. Put BK Test in your SAB projects folder
3. Put the Audacity folder that is inside BK Test Audio under C drive so that the path to the audio files within it is C:\Audacity\audiofile.mp3 (Alternatively, put the Audacity folder into the BK Test folder in your SAB projects folder.)
4. Checkout `master` and run electron-dev
5. Make sure that your SAB projects folder is correct in the setting panel under SAB projects folders
6. Select the BK Test project from the projects dropdown
7. select Matthew chapters 1 and 2
8. Choose the "Generate a single video" option to render the video
9. Watch the video to see how some of the audio is missing in the middle and the audio for the second chapter is higher-pitched (check vs the audio in the Audacity folder)
10. Checkout `bug/audioFrequency` and repeat from step 6 to see how the audio is now correct