### PR TITLE
Fix #256 preview video and image background not showing

### DIFF
--- a/src/App/components/Preview.tsx
+++ b/src/App/components/Preview.tsx
@@ -1,4 +1,3 @@
-import fs from "fs";
 import type CSS from "csstype";
 import classnames from "classnames";
 import _ from "lodash";
@@ -7,7 +6,6 @@ import { observer } from "mobx-react";
 import React from "react";
 import { Flex, Box } from "reflexbox";
 import styled from "styled-components";
-import { BackgroundSettings } from "../../models/animationSettings.model";
 import { TEXT_LOCATION } from "../constants";
 import { useStores } from "../store";
 import AnimatedVisibility from "./AnimatedVisibility";
@@ -85,22 +83,6 @@ const PreviewWord = styled.div`
 const HIGHLIGHT_VERSE_INDEX = 0;
 const HIGHLIGHT_WORD_INDEXES = [0, 1, 2];
 
-const getImageSrc = _.memoize((file: string): string => {
-  if (!file) {
-    return "";
-  }
-  try {
-    const ext: string = file.split(".").pop() || "";
-    if (["png", "jpg", "jpeg", "gif"].includes(ext.toLowerCase())) {
-      const img = fs.readFileSync(file).toString("base64");
-      return `url(data:image/${ext};base64,${img})`;
-    }
-  } catch (err) {
-    console.log(`Failed to load image from '${file}'`);
-  }
-  return "";
-});
-
 const PreviewVerse = (prop: { verse: string; highlightVerse: boolean; highlightColor: string }): JSX.Element => {
   return (
     <>
@@ -117,21 +99,6 @@ const PreviewVerse = (prop: { verse: string; highlightVerse: boolean; highlightC
       })}
     </>
   );
-};
-
-const getViewBlob = (background: BackgroundSettings): string => {
-  if (!background.file) {
-    return "";
-  }
-  const URL = window.URL || window.webkitURL;
-  let video = null;
-  try {
-    video = fs.readFileSync(background.file);
-    const fileURL = URL.createObjectURL(new Blob([video], { type: "video/mp4" }));
-    return fileURL;
-  } catch (err) {
-    return "";
-  }
 };
 
 const Preview = observer((): JSX.Element => {
@@ -157,7 +124,7 @@ const Preview = observer((): JSX.Element => {
   const styles = {
     background: {
       backgroundColor: background.color || "transparent",
-      backgroundImage: getImageSrc(toJS(appState.background.file)),
+      backgroundImage: window.api.getImageSrc(toJS(background.file)),
     },
     speechBubble: {
       opacity: speechBubble.opacity,
@@ -165,7 +132,7 @@ const Preview = observer((): JSX.Element => {
     },
   };
 
-  const file: string = getViewBlob(background);
+  const file: string = window.api.getViewBlob(background.file);
   const versesClassName: string = classnames({
     subtitle: textLocation.location === TEXT_LOCATION.subtitle,
   });

--- a/src/App/components/Settings.tsx
+++ b/src/App/components/Settings.tsx
@@ -8,9 +8,7 @@ import { Flex } from "reflexbox";
 import styled from "styled-components";
 import { repository } from "../../../package.json";
 import { H5, Colors, Text, Card, Button, Checkbox } from "../blueprint";
-import { DEFAULT_OUTPUT_DIRECTORY } from "../constants";
 import { useStores } from "../store";
-import { getDefaultHearThisDirectory, getDefaultScriptureAppBuilderDirectory } from "../store/Settings";
 import { useAnalytics } from "./Analytics";
 import FileSelector from "./FileSelector";
 
@@ -22,8 +20,8 @@ const DirectoryHeading = styled(Flex)`
 
 const descriptionTextClass = classnames(Classes.TEXT_SMALL, Classes.TEXT_MUTED);
 
-const defaultHearThisDirectory = getDefaultHearThisDirectory();
-const defaultAppBuilderDirectory = getDefaultScriptureAppBuilderDirectory();
+const defaultHearThisDirectory = window.api.getDefaultHearThisDirectory();
+const defaultAppBuilderDirectory = window.api.getDefaultScriptureAppBuilderDirectory();
 
 interface DirectoriesCardInterface {
   name: string;
@@ -95,7 +93,7 @@ const Settings = observer((): JSX.Element => {
   const { settings } = useStores();
   const { analytics } = useAnalytics();
   const repoUrl = repository.url.replace(/\.git$/, "");
-  const resetOutputDir = (): void => settings.setOutputDirectory(DEFAULT_OUTPUT_DIRECTORY);
+  const resetOutputDir = (): void => settings.setOutputDirectory(window.api.getDefaultOutputDirectory());
   React.useEffect(() => {
     analytics.trackScreenview("Settings");
   }, [analytics]);

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -1,5 +1,3 @@
-import os from 'os';
-import path from 'path';
 import { BackgroundType, TextLocationLocation } from '../models/animationSettings.model';
 
 export const DEFAULT_BG_COLOR = '#000';
@@ -21,30 +19,14 @@ export const TEXT_LOCATION: { subtitle: TextLocationLocation; center: TextLocati
   center: 'center',
 };
 
-export const DEFAULT_OUTPUT_DIRECTORY = (function (): string {
-  const BK_DIR_NAME = 'Bible Karaoke Videos';
-  switch (process.platform) {
-    case 'win32': {
-      const version = os.release();
-      // if windows 7
-      if (/^6\.1/.test(version)) {
-        return path.join(os.homedir(), 'My Videos', BK_DIR_NAME);
-      } else {
-        return path.join(os.homedir(), 'Videos', BK_DIR_NAME);
-      }
-    }
-    case 'darwin':
-      return path.join(os.homedir(), BK_DIR_NAME);
-    case 'linux':
-    default:
-      return path.join(os.homedir(), 'Videos', BK_DIR_NAME);
-  }
-})();
-
 const allFiles = {
   name: 'All files',
   extensions: ['*'],
 };
+
+export const IMAGE_BG_EXTS = ['jpg', 'png', 'jpeg'];
+
+export const VIDEO_BG_EXTS = ['mp4', 'webm', 'mov'];
 
 export const fileFilters = {
   text: [
@@ -71,7 +53,7 @@ export const fileFilters = {
   background: [
     {
       name: 'Background files',
-      extensions: ['jpg', 'png', 'mp4', 'webm', 'mov'],
+      extensions: [...IMAGE_BG_EXTS, ...VIDEO_BG_EXTS],
     },
   ],
   output: [

--- a/src/App/store/AppState.ts
+++ b/src/App/store/AppState.ts
@@ -12,7 +12,7 @@ import {
   TextSettings,
 } from '../../models/animationSettings.model';
 import { SubmissionArgs, SubmissionReturn } from '../../models/submission.model';
-import { TEXT_LOCATION, BACKGROUND_TYPE, DEFAULT_BG_COLOR } from '../constants';
+import { TEXT_LOCATION, BACKGROUND_TYPE, DEFAULT_BG_COLOR, VIDEO_BG_EXTS } from '../constants';
 import { getChapterDisplayName } from '../util';
 import Store from '.';
 
@@ -32,7 +32,7 @@ const SAMPLE_VERSES = [
     'And there was evening and there was morning, the first day.',
 ];
 
-const isVideo = _.memoize((ext: string): boolean => ['mp4', 'webm', 'mov', 'avi'].includes(ext.toLowerCase()));
+const isVideo = _.memoize((ext: string): boolean => VIDEO_BG_EXTS.includes(ext.toLowerCase()));
 
 class Background implements BackgroundSettings {
   constructor() {

--- a/src/App/store/Settings.ts
+++ b/src/App/store/Settings.ts
@@ -1,30 +1,8 @@
-import os from 'os';
-import path from 'path';
 import { observable, computed, action, makeObservable } from 'mobx';
 import { persist } from 'mobx-persist';
 import { RootDirectories } from '../../models/store.model';
-import { PROJECT_TYPE, DEFAULT_OUTPUT_DIRECTORY } from '../constants';
+import { PROJECT_TYPE } from '../constants';
 import Store from '.';
-
-export const getDefaultHearThisDirectory = (): string => {
-  switch (process.platform) {
-    case 'win32':
-      return 'C:\\ProgramData\\SIL\\HearThis\\';
-    case 'darwin':
-    default:
-      return `${os.homedir()}/hearThisProjects/`;
-  }
-};
-
-export const getDefaultScriptureAppBuilderDirectory = (): string => {
-  switch (process.platform) {
-    case 'win32':
-      return path.join(os.homedir(), 'Documents', 'App Builder', 'Scripture Apps', 'App Projects');
-    case 'darwin':
-    default:
-      return `${os.homedir()}/Documents/AppBuilder/Scripture Apps/App Projects/`;
-  }
-};
 
 class Settings {
   root: Store;
@@ -36,15 +14,15 @@ class Settings {
 
   @persist('list')
   @observable
-  hearThisRootDirectories: string[] = [getDefaultHearThisDirectory()];
+  hearThisRootDirectories: string[] = [window.api.getDefaultHearThisDirectory()];
 
   @persist('list')
   @observable
-  scriptureAppBuilderRootDirectories: string[] = [getDefaultScriptureAppBuilderDirectory()];
+  scriptureAppBuilderRootDirectories: string[] = [window.api.getDefaultScriptureAppBuilderDirectory()];
 
   @persist
   @observable
-  outputDirectory: string = DEFAULT_OUTPUT_DIRECTORY;
+  outputDirectory: string = window.api.getDefaultOutputDirectory();
 
   @persist
   @observable


### PR DESCRIPTION
fs and os don't work on the front end now that we have context isolation

Moved all fs and os calls into preload.ts

I think the best way is to have fs and os only on the back end and accessed with ipc calls but I couldn't get that to work