### PR TITLE
Fix warning introduced in PR #250

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'npm'


### PR DESCRIPTION
- looks like the `cache` option didn't exist for `actions/setup-node@v1`