### PR TITLE
Fix #260 Add select all/clear all checkbox for books panel

### DIFF
--- a/src/App/components/BookSelector.tsx
+++ b/src/App/components/BookSelector.tsx
@@ -17,7 +17,7 @@ const BookSelector = observer((props: CardProps): JSX.Element | null => {
       <Flex alignItems="center" justifyContent="space-between">
         <H3>{project.name}</H3>
         <Checkbox
-          label={project.isSelected ? "Un-select all" : "Select all"}
+          label={project.isSelected ? "Clear all" : "Select all"}
           alignIndicator={Alignment.RIGHT}
           onChange={(): void => {
             project.toggleAllChapters();

--- a/src/App/components/BookSelector.tsx
+++ b/src/App/components/BookSelector.tsx
@@ -1,9 +1,9 @@
-import { Intent } from "@blueprintjs/core";
+import { Alignment, Intent } from "@blueprintjs/core";
 import _ from "lodash";
 import { observer } from "mobx-react";
 import React from "react";
 import { Flex } from "reflexbox";
-import { Button, Card, CardProps, H3, Tag } from "../blueprint";
+import { Button, Card, CardProps, Checkbox, H3, Tag } from "../blueprint";
 import { Book, useStores } from "../store";
 
 const BookSelector = observer((props: CardProps): JSX.Element | null => {
@@ -14,7 +14,18 @@ const BookSelector = observer((props: CardProps): JSX.Element | null => {
   }
   return (
     <Card {...props}>
-      <H3>{project.name}</H3>
+      <Flex alignItems="center" justifyContent="space-between">
+        <H3>{project.name}</H3>
+        <Checkbox
+          label={project.isSelected ? "Un-select all" : "Select all"}
+          alignIndicator={Alignment.RIGHT}
+          onChange={(): void => {
+            project.toggleAllChapters();
+          }}
+          checked={project.allSelected}
+          indeterminate={project.isSelected && !project.allSelected}
+        />
+      </Flex>
       <Flex flexWrap="wrap" m={-1}>
         {project.books.map((book: Book): JSX.Element => {
           let selectionCount = null;

--- a/src/App/components/ChapterSelector.tsx
+++ b/src/App/components/ChapterSelector.tsx
@@ -17,7 +17,7 @@ const ChapterSelector = observer((props: CardProps): JSX.Element => {
           <Flex alignItems="center" justifyContent="space-between">
             <H3>{book.name}</H3>
             <Checkbox
-              label={book.isSelected ? "Un-select all" : "Select all"}
+              label={book.isSelected ? "Clear all" : "Select all"}
               alignIndicator={Alignment.RIGHT}
               onChange={(): void => {
                 book.toggleAllChapters();

--- a/src/App/components/ChapterSelector.tsx
+++ b/src/App/components/ChapterSelector.tsx
@@ -17,7 +17,7 @@ const ChapterSelector = observer((props: CardProps): JSX.Element => {
           <Flex alignItems="center" justifyContent="space-between">
             <H3>{book.name}</H3>
             <Checkbox
-              label={book.allSelected ? "Un-select all" : "Select all"}
+              label={book.isSelected ? "Un-select all" : "Select all"}
               alignIndicator={Alignment.RIGHT}
               onChange={(): void => {
                 book.toggleAllChapters();

--- a/src/App/store/AppState.ts
+++ b/src/App/store/AppState.ts
@@ -134,7 +134,7 @@ export class Book implements BKBook {
 
   @action.bound
   toggleAllChapters(): void {
-    const isSelected = this.allSelected;
+    const isSelected = this.isSelected;
     this.chapters.forEach((chapter: Chapter) => chapter.setIsSelected(!isSelected));
   }
 
@@ -192,6 +192,30 @@ export class Project implements BKProject {
       },
       0
     );
+  }
+
+  @computed({ keepAlive: true })
+  get isSelected(): boolean {
+    return this.books.some((b: Book) => {
+      return _.some(b.chapters, 'isSelected');
+    });
+  }
+
+  @computed({ keepAlive: true })
+  get allSelected(): boolean {
+    return this.books.every((b: Book) => {
+      return _.every(b.chapters, 'isSelected');
+    });
+  }
+
+  @action.bound
+  toggleAllChapters(): void {
+    const isSelected = this.isSelected;
+    this.books.forEach((b: Book) => {
+      b.chapters.forEach((c: Chapter) => {
+        c.isSelected = !isSelected;
+      });
+    });
   }
 
   @computed({ keepAlive: true })

--- a/src/App/store/AppState.ts
+++ b/src/App/store/AppState.ts
@@ -196,16 +196,12 @@ export class Project implements BKProject {
 
   @computed({ keepAlive: true })
   get isSelected(): boolean {
-    return this.books.some((book: Book) => {
-      return book.isSelected;
-    });
+    return this.books.some((book: Book) => book.isSelected);
   }
 
   @computed({ keepAlive: true })
   get allSelected(): boolean {
-    return this.books.every((book: Book) => {
-      return book.allSelected;
-    });
+    return this.books.every((book: Book) => book.allSelected);
   }
 
   @action.bound

--- a/src/App/store/AppState.ts
+++ b/src/App/store/AppState.ts
@@ -196,24 +196,24 @@ export class Project implements BKProject {
 
   @computed({ keepAlive: true })
   get isSelected(): boolean {
-    return this.books.some((b: Book) => {
-      return _.some(b.chapters, 'isSelected');
+    return this.books.some((book: Book) => {
+      return book.isSelected;
     });
   }
 
   @computed({ keepAlive: true })
   get allSelected(): boolean {
-    return this.books.every((b: Book) => {
-      return _.every(b.chapters, 'isSelected');
+    return this.books.every((book: Book) => {
+      return book.allSelected;
     });
   }
 
   @action.bound
   toggleAllChapters(): void {
     const isSelected = this.isSelected;
-    this.books.forEach((b: Book) => {
-      b.chapters.forEach((c: Chapter) => {
-        c.isSelected = !isSelected;
+    this.books.forEach((book: Book) => {
+      book.chapters.forEach((chapter: Chapter) => {
+        chapter.isSelected = !isSelected;
       });
     });
   }


### PR DESCRIPTION
Changed the labels from "Un-select all" to "Clear all" as recommended by the Microsoft Writing Style Guide:
https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/u/uncheck-unmark-unselect

Changed the way the select all checkboxes work when some are already selected, from selecting all to clearing all as this is how it works in gmail. I tried finding some official recommendation as to how this should work but couldn't find anything.