### PR TITLE
Fix #257 Remove green dots in book selector panel

### DIFF
--- a/src/App/blueprint.ts
+++ b/src/App/blueprint.ts
@@ -64,9 +64,6 @@ export const Radio: StyledComponent<typeof BP.Radio, object, {} & SLFProps> = st
 export const HTMLSelect: StyledComponent<typeof BP.HTMLSelect, object, {} & SLFProps> = styled(BP.HTMLSelect)`
   ${space} ${layout} ${flexbox}
 `;
-export const Tag: StyledComponent<typeof BP.Tag, object, {} & SLFPProps> = styled(BP.Tag)`
-  ${space} ${layout} ${flexbox} ${position}
-`;
 
 export const Colors: { [x: string]: string } = {
   logo: '#006666',

--- a/src/App/components/BookSelector.tsx
+++ b/src/App/components/BookSelector.tsx
@@ -3,7 +3,7 @@ import _ from "lodash";
 import { observer } from "mobx-react";
 import React from "react";
 import { Flex } from "reflexbox";
-import { Button, Card, CardProps, Checkbox, H3, Tag } from "../blueprint";
+import { Button, Card, CardProps, Checkbox, H3 } from "../blueprint";
 import { Book, useStores } from "../store";
 
 const BookSelector = observer((props: CardProps): JSX.Element | null => {
@@ -28,10 +28,6 @@ const BookSelector = observer((props: CardProps): JSX.Element | null => {
       </Flex>
       <Flex flexWrap="wrap" m={-1}>
         {project.books.map((book: Book): JSX.Element => {
-          let selectionCount = null;
-          if (book.isSelected) {
-            selectionCount = _.indexOf(project.bookSelection, book.name) + 1;
-          }
           return (
             <Button
               position="relative"
@@ -44,11 +40,6 @@ const BookSelector = observer((props: CardProps): JSX.Element | null => {
               active={project.activeBookName === book.name}
             >
               {book.name}
-              {book.isSelected && project.bookSelection.length > 1 && (
-                <Tag position="absolute" style={{ zIndex: 2 }} right="-10px" top="-10px" round intent={Intent.SUCCESS}>
-                  {selectionCount}
-                </Tag>
-              )}
             </Button>
           );
         })}

--- a/src/App/components/BookSelector.tsx
+++ b/src/App/components/BookSelector.tsx
@@ -1,5 +1,4 @@
 import { Alignment, Intent } from "@blueprintjs/core";
-import _ from "lodash";
 import { observer } from "mobx-react";
 import React from "react";
 import { Flex } from "reflexbox";


### PR DESCRIPTION
They were to indicate the order in which the books had been selected, with the idea being that a combined video would combine in that order.
However we have decided that it would be better ux to make choosing the order of combining separate from selecting the chapters.