### PR TITLE
Add deprecation warnings to lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,12 +12,13 @@
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
+    "project": ["tsconfig.json", "main/tsconfig.json", "tsconfig.spec.json"],
     "ecmaFeatures": {
       "jsx": true
     },
     "ecmaVersion": 2018
   },
-  "plugins": ["react", "@typescript-eslint", "eslint-plugin-import"],
+  "plugins": ["react", "@typescript-eslint", "eslint-plugin-import", "deprecation"],
   "settings": {
     "react": {
       "version": "detect"
@@ -30,6 +31,7 @@
         "files": ["**/*.{spec,integration}.{ts,js}"]
       }
     ],
+    "deprecation/deprecation": "warn",
     "import/order": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "electron-devtools-installer": "^3.2.0",
         "electron-reload": "^1.5.0",
         "eslint-plugin-ava": "^10.5.0",
+        "eslint-plugin-deprecation": "^1.3.2",
         "eslint-plugin-react": "^7.33.1",
         "ffbinaries": "^1.1.5",
         "husky": "^6.0.0",
@@ -9741,6 +9742,204 @@
       "peerDependencies": {
         "eslint": ">=6.2.0"
       }
+    },
+    "node_modules/eslint-plugin-deprecation": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.2.tgz",
+      "integrity": "sha512-z93wbx9w7H/E3ogPw6AZMkkNJ6m51fTZRNZPNQqxQLmx+KKt7aLkMU9wN67s71i+VVHN4tLOZ3zT3QLbnlC0Mg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "typescript": "^3.7.5 || ^4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.18.0.tgz",
+      "integrity": "sha512-hypiw5N0aM2aH91/uMmG7RpyUH3PN/iOhilMwkMFZIbm/Bn/G3ZnbaYdSoAN4PG/XHQjdhBYLi0ZoRZsRYT4hA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "5.18.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz",
+      "integrity": "sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.18.0",
+        "@typescript-eslint/visitor-keys": "5.18.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/types": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.18.0.tgz",
+      "integrity": "sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz",
+      "integrity": "sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.18.0",
+        "@typescript-eslint/visitor-keys": "5.18.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/utils": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.18.0.tgz",
+      "integrity": "sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.18.0",
+        "@typescript-eslint/types": "5.18.0",
+        "@typescript-eslint/typescript-estree": "5.18.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz",
+      "integrity": "sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.18.0",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/lru-cache": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+      "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/semver": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^7.4.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.26.0",
@@ -29695,6 +29894,127 @@
         "micro-spelling-correcter": "^1.1.1",
         "pkg-dir": "^4.2.0",
         "resolve-from": "^5.0.0"
+      }
+    },
+    "eslint-plugin-deprecation": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.2.tgz",
+      "integrity": "sha512-z93wbx9w7H/E3ogPw6AZMkkNJ6m51fTZRNZPNQqxQLmx+KKt7aLkMU9wN67s71i+VVHN4tLOZ3zT3QLbnlC0Mg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.18.0.tgz",
+          "integrity": "sha512-hypiw5N0aM2aH91/uMmG7RpyUH3PN/iOhilMwkMFZIbm/Bn/G3ZnbaYdSoAN4PG/XHQjdhBYLi0ZoRZsRYT4hA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/utils": "5.18.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz",
+          "integrity": "sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.18.0",
+            "@typescript-eslint/visitor-keys": "5.18.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.18.0.tgz",
+          "integrity": "sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz",
+          "integrity": "sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.18.0",
+            "@typescript-eslint/visitor-keys": "5.18.0",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.18.0.tgz",
+          "integrity": "sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.18.0",
+            "@typescript-eslint/types": "5.18.0",
+            "@typescript-eslint/typescript-estree": "5.18.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz",
+          "integrity": "sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.18.0",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+              "dev": true
+            }
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "7.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+          "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^7.4.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "electron-devtools-installer": "^3.2.0",
     "electron-reload": "^1.5.0",
     "eslint-plugin-ava": "^10.5.0",
+    "eslint-plugin-deprecation": "^1.3.2",
     "eslint-plugin-react": "^7.33.1",
     "ffbinaries": "^1.1.5",
     "husky": "^6.0.0",

--- a/src/App/components/Actions.tsx
+++ b/src/App/components/Actions.tsx
@@ -58,7 +58,7 @@ const TextWrapper = styled(Flex).attrs({
   flexDirection: "column",
 })``;
 
-const ProgressText = (prop: { progress?: Progress }): JSX.Element => {
+const ProgressText = (prop: { progress?: Progress }): React.JSX.Element => {
   if (prop.progress == null) {
     return <Text></Text>;
   }
@@ -85,7 +85,7 @@ const Action = observer(
     combined: boolean;
     mainText: string;
     subText: string;
-  }): JSX.Element => {
+  }): React.JSX.Element => {
     const { appState } = useStores();
     const progress: Progress | undefined = appState.progress.combined === prop.combined ? appState.progress : undefined;
     const inProgress = _.get(progress, "inProgress");
@@ -120,7 +120,7 @@ const Action = observer(
   }
 );
 
-const Actions = observer((): JSX.Element => {
+const Actions = observer((): React.JSX.Element => {
   const { appState } = useStores();
   const { analytics } = useAnalytics();
 

--- a/src/App/components/Analytics.tsx
+++ b/src/App/components/Analytics.tsx
@@ -18,8 +18,8 @@ interface AnalyticsProviderSettings {
 
 export function AnalyticsProvider(prop: {
   settings: AnalyticsProviderSettings;
-  children: JSX.Element[] | JSX.Element;
-}): JSX.Element {
+  children: React.JSX.Element[] | React.JSX.Element;
+}): React.JSX.Element {
   const [analyticsNoticeDisplayed, setAnalyticsNoticeDisplayed] = React.useState(localStorage.analyticsNoticeDisplayed);
   const [analytics] = React.useState<AnalyticsInterface>(new Analytics(prop.settings));
 

--- a/src/App/components/AnimatedVisibility.tsx
+++ b/src/App/components/AnimatedVisibility.tsx
@@ -17,10 +17,10 @@ const Wrapper = styled(Box)`
 
 interface AnimatedVisibilityProps {
   visible: boolean;
-  children: JSX.Element[] | JSX.Element;
+  children: React.JSX.Element[] | React.JSX.Element;
 }
 
-export default function AnimatedVisibility(prop: AnimatedVisibilityProps): JSX.Element {
+export default function AnimatedVisibility(prop: AnimatedVisibilityProps): React.JSX.Element {
   return (
     <Wrapper flex={1} className={classnames({ visible: prop.visible })}>
       {prop.children}

--- a/src/App/components/AppHeader.tsx
+++ b/src/App/components/AppHeader.tsx
@@ -84,7 +84,7 @@ const HeaderWrapper = styled(Flex)`
   }
 `;
 
-const AppHeader = observer((): JSX.Element => {
+const AppHeader = observer((): React.JSX.Element => {
   const { appState } = useStores();
   return (
     <HeaderBackground>

--- a/src/App/components/BookSelector.tsx
+++ b/src/App/components/BookSelector.tsx
@@ -5,7 +5,7 @@ import { Flex } from "reflexbox";
 import { Button, Card, CardProps, Checkbox, H3 } from "../blueprint";
 import { Book, useStores } from "../store";
 
-const BookSelector = observer((props: CardProps): JSX.Element | null => {
+const BookSelector = observer((props: CardProps): React.JSX.Element | null => {
   const { appState } = useStores();
   const project = appState.projects.activeProject;
   if (!project) {
@@ -26,7 +26,7 @@ const BookSelector = observer((props: CardProps): JSX.Element | null => {
         />
       </Flex>
       <Flex flexWrap="wrap" m={-1}>
-        {project.books.map((book: Book): JSX.Element => {
+        {project.books.map((book: Book): React.JSX.Element => {
           return (
             <Button
               position="relative"

--- a/src/App/components/ChapterSelector.tsx
+++ b/src/App/components/ChapterSelector.tsx
@@ -7,7 +7,7 @@ import { Button, Card, CardProps, Checkbox, H3 } from "../blueprint";
 import { Chapter, useStores } from "../store";
 import { getChapterDisplayName } from "../util";
 
-const ChapterSelector = observer((props: CardProps): JSX.Element => {
+const ChapterSelector = observer((props: CardProps): React.JSX.Element => {
   const { appState } = useStores();
   const book = _.get(appState.projects, ["activeProject", "activeBook"]);
   return (

--- a/src/App/components/ColorPicker.tsx
+++ b/src/App/components/ColorPicker.tsx
@@ -82,7 +82,7 @@ export default class ColorPicker extends React.Component<ColorPickerProps> {
     };
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <Popover disabled={this.props.disabled}>
         <Swatch

--- a/src/App/components/Editors/BackgroundEditor.tsx
+++ b/src/App/components/Editors/BackgroundEditor.tsx
@@ -14,7 +14,7 @@ const EditRadio = styled(Radio).attrs({
   mb: 0,
 })``;
 
-const BackgroundEditor = observer((props: EditPopoverProps): JSX.Element => {
+const BackgroundEditor = observer((props: EditPopoverProps): React.JSX.Element => {
   const { appState } = useStores();
   const { background } = appState;
   return (

--- a/src/App/components/Editors/EditPopover.tsx
+++ b/src/App/components/Editors/EditPopover.tsx
@@ -17,11 +17,16 @@ export const EditRow = styled(Flex).attrs({
 
 export interface EditPopoverProps extends PositionProps, BoxProps {
   icon?: IconName | MaybeElement;
-  title?: string | JSX.Element;
-  children?: JSX.Element | JSX.Element[];
+  title?: string | React.JSX.Element;
+  children?: React.JSX.Element | React.JSX.Element[];
 }
 
-export default function EditPopover({ icon = "annotation", title, children, ...props }: EditPopoverProps): JSX.Element {
+export default function EditPopover({
+  icon = "annotation",
+  title,
+  children,
+  ...props
+}: EditPopoverProps): React.JSX.Element {
   return (
     <Wrapper top="8px" right="8px" {...props}>
       <Popover position={PopoverPosition.RIGHT_TOP} interactionKind={PopoverInteractionKind.CLICK}>

--- a/src/App/components/Editors/FontEditor.tsx
+++ b/src/App/components/Editors/FontEditor.tsx
@@ -12,7 +12,7 @@ const FONT_SIZES = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20].map((n) => ({
   label: `${n}pt`,
 }));
 
-const FontEditor = observer((props: EditPopoverProps): JSX.Element => {
+const FontEditor = observer((props: EditPopoverProps): React.JSX.Element => {
   const { appState } = useStores();
   const [fonts, setFonts] = React.useState<OptionProps[]>();
 

--- a/src/App/components/Editors/SpeechBubbleEditor.tsx
+++ b/src/App/components/Editors/SpeechBubbleEditor.tsx
@@ -13,7 +13,7 @@ const StyleColorPicker = styled(ColorPicker).attrs({
   mr: 3,
 })``;
 
-const SpeechBubbleEditor = observer((props: EditPopoverProps): JSX.Element => {
+const SpeechBubbleEditor = observer((props: EditPopoverProps): React.JSX.Element => {
   const { appState } = useStores();
 
   const setSpeechBubbleColor = (color: ColorResult): void => {

--- a/src/App/components/FileSelector.tsx
+++ b/src/App/components/FileSelector.tsx
@@ -12,7 +12,7 @@ const FileSelector = (prop: {
   file?: string;
   options: SaveDialogOptions | OpenDialogOptions;
   onFileSelected: (file: string) => void;
-}): JSX.Element => {
+}): React.JSX.Element => {
   const selectFile = async (): Promise<void> => {
     if (prop.save) {
       window.api.onFileSave((saveFilePath: string) => {
@@ -22,7 +22,7 @@ const FileSelector = (prop: {
       });
       window.api.saveFile(prop.options as SaveDialogOptions);
     } else {
-      window.api.onFileOpen(( openFilePaths: string) => {
+      window.api.onFileOpen((openFilePaths: string) => {
         const openFilePath = openFilePaths && openFilePaths.length === 1 ? openFilePaths[0] : "";
         if (openFilePath) {
           prop.onFileSelected(openFilePath);

--- a/src/App/components/Preview.tsx
+++ b/src/App/components/Preview.tsx
@@ -99,7 +99,7 @@ async function getViewBlob(file: string): Promise<string> {
   return "";
 }
 
-const PreviewVerse = (prop: { verse: string; highlightVerse: boolean; highlightColor: string }): JSX.Element => {
+const PreviewVerse = (prop: { verse: string; highlightVerse: boolean; highlightColor: string }): React.JSX.Element => {
   return (
     <>
       {prop.verse.split(" ").map((word, index) => {
@@ -117,7 +117,7 @@ const PreviewVerse = (prop: { verse: string; highlightVerse: boolean; highlightC
   );
 };
 
-const Preview = observer((): JSX.Element => {
+const Preview = observer((): React.JSX.Element => {
   const { appState } = useStores();
   const firstChapter = _.get(appState, ["projects", "firstSelectedChapter"]);
   const { verses, background, speechBubble, text, textLocation } = appState;

--- a/src/App/components/ProjectSelector.tsx
+++ b/src/App/components/ProjectSelector.tsx
@@ -5,7 +5,7 @@ import { SOURCE_TYPES } from "../constants";
 import { Project, useStores } from "../store";
 import { useAnalytics } from "./Analytics";
 
-const ProjectSelector = observer((): JSX.Element => {
+const ProjectSelector = observer((): React.JSX.Element => {
   const { appState } = useStores();
   const { analytics } = useAnalytics();
   const onChange = React.useCallback(

--- a/src/App/components/Settings.tsx
+++ b/src/App/components/Settings.tsx
@@ -27,7 +27,7 @@ interface DirectoriesCardInterface {
   defaultDirectory: string;
 }
 
-const DirectoriesCard = (prop: DirectoriesCardInterface): JSX.Element => {
+const DirectoriesCard = (prop: DirectoriesCardInterface): React.JSX.Element => {
   const addDirectory = (folder: string): void => {
     prop.onSetDirectories(_.uniq([...prop.directories, folder]));
   };
@@ -86,7 +86,7 @@ DirectoriesCard.propTypes = {
   defaultDirectory: PropTypes.string,
 };
 
-const Settings = observer((): JSX.Element => {
+const Settings = observer((): React.JSX.Element => {
   const [defaultHearThisDirectory, setDefaultHearThisDirectory] = React.useState("");
   const [defaultAppBuilderDirectory, setDefaultAppBuilderDirectory] = React.useState("");
   const { settings } = useStores();

--- a/src/App/components/SettingsButton.tsx
+++ b/src/App/components/SettingsButton.tsx
@@ -5,7 +5,7 @@ import packageData from "../../../package.json";
 import { Button, Text } from "../blueprint";
 import Settings from "./Settings";
 
-export default function SettingsButton(): JSX.Element {
+export default function SettingsButton(): React.JSX.Element {
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   return (
     <React.Fragment>

--- a/src/App/components/TextLocationToggle.tsx
+++ b/src/App/components/TextLocationToggle.tsx
@@ -17,7 +17,7 @@ const Wrapper = styled(Box)`
   }
 `;
 
-const TextLocationToggle = observer((props: PositionProps | BoxProps): JSX.Element => {
+const TextLocationToggle = observer((props: PositionProps | BoxProps): React.JSX.Element => {
   const { appState } = useStores();
   const toggleTextLocation = React.useCallback(() => {
     appState.setTextLocation({

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -18,7 +18,7 @@ const AppWrapper: StyledComponent<BoxType, Record<string, unknown>> = styled(Fle
   position: relative;
 `;
 
-const App = observer((): JSX.Element => {
+const App = observer((): React.JSX.Element => {
   const { settings } = useStores();
   const analyticsContext: AnalyticsContext = useAnalytics();
 


### PR DESCRIPTION
Note the remain 8 deprecations: the first (electron.ts:on) is more involved but will need to be fixed before (or with) moving to the next electron version (v15); the other 7 require moving to `@blueprint/core` v4.

Don't merge this until the deprecations are fixed since it will fail the GHA builds (like you see below in this PR).